### PR TITLE
Migrate away from redundant update functions

### DIFF
--- a/Sources/Spinner/Spinner.swift
+++ b/Sources/Spinner/Spinner.swift
@@ -4,27 +4,18 @@ import Rainbow
 import Signals
 
 public final class Spinner {
-
-    /// Pattern holding frames to be animated    
-    var pattern: SpinnerPattern {
+    public var pattern: SpinnerPattern {
         didSet {
             self.frameIndex = 0
         }
     }
-    /// Text that is  displayed next to spinner
-    var text: String
-    /// Boolean representing fs the spinner is currently animating
+    public  var text: String
+    public var color: Color
+    public  var format: String
+    public var speed: Double
     var running: Bool
-    /// Int representing the index of the current frame
     var frameIndex: Int
-    /// Double repenting the wait time for frame animation
-    var speed: Double
-    /// Dispatch queue that the spinner will run within
     var queue: DispatchQueue
-    /// Color of the spinner
-    var color: Color
-    /// Format of the Spinner
-    var format: String
 
     /**
     Create new spinner 
@@ -85,52 +76,7 @@ public final class Spinner {
     Clears the spinner from the terminal and returns the curser to the start of the spinner
     */
     public func clear() {
-        self.stopSpinner(finalFrame: "", text: "", terminator: "\r")
-    }
-
-    /**
-    Updates the pattern displayed by the spinner
-
-    - Parameter _: SpinnerPattern - New pattern the spinner should animate over
-    */
-    public func updatePattern(_ newPattern: SpinnerPattern) {
-        self.setPattern(newPattern)
-    }
-
-    /**
-    Updates the text displayed next to the spinner
-    
-    - Parameter _: String - New text the spinner should display
-    */
-    public func updateText(_ newText: String) {
-        self.setText(newText)
-    }
-
-    /**
-    Updates the speed of the spinner
-
-    - Parameter _: Double - New speed the spinner should animate at
-    */
-    public func updateSpeed(_ newSpeed: Double) {
-        self.setSpeed(newSpeed)
-    } 
-
-    /**
-    Updates the color of the spinner
-
-    - Parameter _: Color - New color for the spinner
-    */
-    public func updateColor(_ newColor: Color) {
-        self.setColor(newColor)
-    }
-
-    /**
-    Updates the format the spinier will render as
-
-    - Parameter _: String - New format for spinner to display as
-    */
-    public func updateFormat(_ newFormat: String) {
-        self.setFormat(newFormat)
+        self.stop(finalFrame: "", text: "", terminator: "\r")
     }
 
     /**

--- a/Sources/Spinner/Spinner.swift
+++ b/Sources/Spinner/Spinner.swift
@@ -32,7 +32,6 @@ public final class Spinner {
         self.speed = speed ?? pattern.defaultSpeed
         self.color = color
         self.format = format.uppercased()
-
         self.frameIndex = 0
         self.running = false
         self.queue = DispatchQueue(label: "io.Swift.Spinner")
@@ -50,9 +49,7 @@ public final class Spinner {
         self.hideCursor()
         self.running = true
         self.queue.async { [weak self] in
-
             guard let `self` = self else { return }
-
             while self.running {
                 self.renderSpinner()
                 self.sleep(seconds: self.speed)
@@ -129,12 +126,9 @@ public final class Spinner {
     }
 
     func getTextPadding(_ newText: String) -> Int {
-
         let newText = Rainbow.extractModes(for: newText)
         let oldText = Rainbow.extractModes(for: self.text)
-
         let textLengthDifference: Int = oldText.text.count - newText.text.count
-
         if textLengthDifference > 0 {
             return textLengthDifference
         } else {
@@ -143,12 +137,9 @@ public final class Spinner {
     }
 
     func getPatternPadding(_ newPattern: SpinnerPattern) -> Int {
-        
         let newPatternFrameWidth: Int = Rainbow.extractModes(for: newPattern.frames[0]).text.count
         let oldPatternFrameWidth: Int = Rainbow.extractModes(for: self.pattern.frames[0]).text.count
-
         let patternFrameWidthDifference: Int = oldPatternFrameWidth - newPatternFrameWidth
-
         if patternFrameWidthDifference > 0 {
             return patternFrameWidthDifference
         }else {
@@ -161,22 +152,15 @@ public final class Spinner {
     }
 
     func currentFrame() -> String {
-
         let currentFrame = self.pattern.frames[self.frameIndex].applyingCodes(self.color)
-
         self.frameIndex = (self.frameIndex + 1) % self.pattern.frames.count
-
         return currentFrame
     }
 
     func renderSpinner() {
-
-        // Reset cursor to start of line
         print("\r", terminator: "")
-        // Print the spinner frame and text
         let  renderString = self.format.replacingOccurrences(of: "{S}", with: self.currentFrame()).replacingOccurrences(of: "{T}", with: self.text)
         print(renderString, terminator: "")
-        // Flush STDOUT
         fflush(stdout)
 
     }

--- a/Sources/Spinner/Spinner.swift
+++ b/Sources/Spinner/Spinner.swift
@@ -69,7 +69,20 @@ public final class Spinner {
     - Parameter terminator: String - The terminator used for ending writing a line to the terminal, default is '\n' this will return the curser to a new line
     */
     public func stop(finalFrame: String? = nil, text: String? = nil, color: Color? = nil, terminator: String = "\n") {
-        self.stopSpinner(finalFrame: finalFrame, text: text, color: color, terminator: terminator)
+        self.running = false
+        self.text = text ?? self.text
+        self.color = color ?? self.color
+        var finalPattern: SpinnerPattern?
+        if let frame = finalFrame {
+            finalPattern = SpinnerPattern(singleFrame: frame)
+        }
+        if let pattern = finalPattern {
+            self.text += Array(repeating: " ", count: self.getPatternPadding(pattern))
+            self.pattern = pattern
+        }
+        self.unhideCursor()
+        self.renderSpinner()
+        print(terminator: terminator)
     }
 
     /**
@@ -85,7 +98,7 @@ public final class Spinner {
    - Parameter _: String The persistent text that will be displayed on the completed spinner, default will keep the current text of the spinner 
     */
     public func succeed(_ text: String? = nil) {
-        self.stopSpinner(finalFrame: "✔", text: text, color: .green)
+        self.stop(finalFrame: "✔", text: text, color: .green)
     }
 
     /**
@@ -94,7 +107,7 @@ public final class Spinner {
     - Parameter _: String The persistent text that will be displayed on the completed spinner
     */
     public func failure(_ text: String? = nil) {
-        self.stopSpinner(finalFrame: "✖", text: text, color: .red)
+        self.stop(finalFrame: "✖", text: text, color: .red)
     }
 
     /**
@@ -103,7 +116,7 @@ public final class Spinner {
     - Parameter _: String The persistent text that will be displayed on the completed spinner,  default will keep the current text of the spinner 
     */
     public func warning(_ text: String? = nil) {
-        self.stopSpinner(finalFrame: "⚠", text: text, color: .yellow)
+        self.stop(finalFrame: "⚠", text: text, color: .yellow)
     }
 
     /**
@@ -112,50 +125,7 @@ public final class Spinner {
     - Parameter _: String The persistent text that will be displayed on the completed spinner,  default will keep the current text of the spinner 
     */
     public func information(_ text: String? = nil) {
-        self.stopSpinner(finalFrame: "ℹ", text: text, color: .blue)
-    }
-
-    func stopSpinner(finalFrame: String? = nil, text: String? = nil, color: Color? = nil, terminator: String = "\n") {
-        self.running = false
-        if let text = text {
-            setText(text)
-        }
-        if let color = color {
-            setColor(color)
-        }
-        var finalPattern: SpinnerPattern?
-        if let frame = finalFrame {
-            finalPattern = SpinnerPattern(singleFrame: frame)
-        }
-        if let pattern = finalPattern {
-            self.text += Array(repeating: " ", count: self.getPatternPadding(pattern))
-            self.pattern = pattern
-        }
-        self.unhideCursor()
-        self.renderSpinner()
-        print(terminator: terminator)
-    }
-
-    func setColor(_ newColor: Color) {
-        self.color = newColor
-    }
-
-    func setPattern(_ newPattern: SpinnerPattern) {
-        self.format += Array(repeating: " ", count: self.getPatternPadding(newPattern))
-        self.pattern = newPattern
-    }
-
-    func setSpeed(_ newSpeed: Double) {
-        self.speed = newSpeed
-    }
-
-    func setFormat(_ newFormat: String) {
-        self.format = newFormat
-    }
-
-    func setText(_ newText: String) {
-        self.format += Array(repeating: " ", count: self.getTextPadding(newText))
-        self.text = newText
+        self.stop(finalFrame: "ℹ", text: text, color: .blue)
     }
 
     func getTextPadding(_ newText: String) -> Int {

--- a/Tests/SpinnerTests/SpinnerTests.swift
+++ b/Tests/SpinnerTests/SpinnerTests.swift
@@ -16,7 +16,7 @@ final class SpinnerTests: XCTestCase {
         let testSpinner = Spinner(.dots, "testSpinner")
         XCTAssertEqual("testSpinner", testSpinner.text)
         testSpinner.start()
-        testSpinner.updateText("Spinner")
+        testSpinner.text = "Spinner"
         XCTAssertEqual("Spinner", testSpinner.text)
         testSpinner.clear()
     }


### PR DESCRIPTION
The library is cluttered with functions to update spinner properties. This makes the source hard to read while adding unnecessary complexity to the API and documentation. This PR includes **BREAKING CHANGES** and should only be merged when ready to release a new major version. All functions used to update **Spinner** properties have been removed and replaced by making their raw variables publicly accessible. API, therefore, changes from:

``` swift
mySpinner.updateText("foo")
```

To this:

``` swift
mySpinner.text = "foo"
```