### PR TITLE
Remove all tests var

### DIFF
--- a/Tests/SpinnerTests/SpinnerTests.swift
+++ b/Tests/SpinnerTests/SpinnerTests.swift
@@ -20,9 +20,4 @@ final class SpinnerTests: XCTestCase {
         XCTAssertEqual("Spinner", testSpinner.text)
         testSpinner.clear()
     }
-
-    static var allTests = [
-        ("testSpinnerState", testSpinnerState),
-        ("testSpinnerText", testSpinnerText)
-    ]
 }


### PR DESCRIPTION
Removes `allTests` var from test files as it now no longer needed as Linux tests are ran with the new test discovery.