### PR TITLE
Add SpinnerUI protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .build/
 *.xcodeproj
 Package.resolved
+.swiftpm/

--- a/Sources/Spinner/Spinner.swift
+++ b/Sources/Spinner/Spinner.swift
@@ -4,7 +4,6 @@ import Dispatch
 import Rainbow
 import Signals
 
-
 struct StdOutSpinnerUI: SpinnerUI {
     public func display(string: String) {
         // Reset cursor to start of line
@@ -23,6 +22,10 @@ struct StdOutSpinnerUI: SpinnerUI {
     public func unhideCursor() {
         print("\u{001B}[?25h", terminator: "")
         fflush(stdout)
+    }
+  
+    public func print(_ str: String = "", terminator: String) {
+      Swift.print(str, terminator: terminator)
     }
 }
 
@@ -72,7 +75,7 @@ public final class Spinner {
         self.frameIndex = 0
         self.running = false
         self.queue = DispatchQueue(label: "io.Swift.Spinner")
-    self.ui = ui ?? StdOutSpinnerUI()
+        self.ui = ui ?? StdOutSpinnerUI()
 
         Signals.trap(signal: .int) { _ in
             print("\u{001B}[?25h", terminator: "")
@@ -124,7 +127,7 @@ public final class Spinner {
         }
         self.unhideCursor()
         self.renderSpinner()
-        print(terminator: terminator)
+        self.ui.print("", terminator: terminator)
     }
 
     /**

--- a/Sources/Spinner/Spinner.swift
+++ b/Sources/Spinner/Spinner.swift
@@ -7,25 +7,26 @@ import Signals
 struct StdOutSpinnerUI: SpinnerUI {
     public func display(string: String) {
         // Reset cursor to start of line
-        print("\r", terminator: "")
+        Swift.print("\r", terminator: "")
         // Print the spinner frame and text
-        print(string, terminator: "")
+        Swift.print(string, terminator: "")
         // Flush STDOUT
         fflush(stdout)
     }
     
     public func hideCursor() {
-        print("\u{001B}[?25l", terminator: "")
+        Swift.print("\u{001B}[?25l", terminator: "")
         fflush(stdout)
     }
     
     public func unhideCursor() {
-        print("\u{001B}[?25h", terminator: "")
+        Swift.print("\u{001B}[?25h", terminator: "")
         fflush(stdout)
     }
   
-    public func print(_ str: String = "", terminator: String) {
-      Swift.print(str, terminator: terminator)
+    public func printString(_ str: String) {
+      Swift.print(str, terminator: "")
+      fflush(stdout)
     }
 }
 
@@ -127,7 +128,8 @@ public final class Spinner {
         }
         self.unhideCursor()
         self.renderSpinner()
-        self.ui.print("", terminator: terminator)
+//        print(terminator)
+        self.ui.printString(terminator)
     }
 
     /**

--- a/Sources/Spinner/SpinnerUI.swift
+++ b/Sources/Spinner/SpinnerUI.swift
@@ -1,0 +1,6 @@
+
+public protocol SpinnerUI {
+    func display(string: String)
+    func hideCursor()
+    func unhideCursor()
+}

--- a/Sources/Spinner/SpinnerUI.swift
+++ b/Sources/Spinner/SpinnerUI.swift
@@ -3,5 +3,5 @@ public protocol SpinnerUI {
     func display(string: String)
     func hideCursor()
     func unhideCursor()
-    func print(_ str: String, terminator: String)
+    func printString(_ str: String)
 }

--- a/Sources/Spinner/SpinnerUI.swift
+++ b/Sources/Spinner/SpinnerUI.swift
@@ -3,4 +3,5 @@ public protocol SpinnerUI {
     func display(string: String)
     func hideCursor()
     func unhideCursor()
+    func print(_ str: String, terminator: String)
 }


### PR DESCRIPTION
Hello,

Thank you for your package. It is really easy to make powerful CLI with it.
We found one issue with it though. This library assumes that output goes to stdout. In iOS and [SwiftCLI](https://github.com/jakeheis/SwiftCLI) it not a case. SwiftCLI provides it's own abstraction (`WritableStream`) on stdout.

So I extracted all rendering to `SpinnerUI` protocol and moved `Stdout` implementation to `StdOutSpinnerUI`.
I didn't added SwiftCLI implementation, but it will look like this:

```swift

struct SwiftCLISpinnerUI: SpinnerUI {
  private let _stdout: WritableStream
  
  init(stdout: WritableStream) {
    _stdout = stdout
  }
  
  func display(string: String) {
    _stdout.write("\r" + string)
  }
  
  func hideCursor() {
    _stdout.write("\u{001B}[?25l")
  }
  
  func unhideCursor() {
    _stdout.write("\u{001B}[?25h")
  }
  
}
```

Inside commands I can use Spinner like this now:

```swift
let spinner Spinner(.dots, message, ui: SwiftCLISpinnerUI(stdout: stdout))
```