### PR TITLE
deps: upgrade rainbow from 3.0.0 to 4.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/dominicegginton/Nanoseconds", from: "1.1.2"),
-        .package(url: "https://github.com/onevcat/Rainbow", from: "3.0.0"),
+        .package(url: "https://github.com/onevcat/Rainbow", from: "4.0.0"),
         .package(url: "https://github.com/IBM-Swift/BlueSignals.git", from: "1.0.0")
     ],
     targets: [

--- a/Sources/Spinner/Spinner.swift
+++ b/Sources/Spinner/Spinner.swift
@@ -201,9 +201,16 @@ public final class Spinner {
         self.stop(frame: "ℹ", message: message, color: .blue)
     }
 
+    func entryLength(entry: Rainbow.Entry) -> Int {
+      if let segment = entry.segments.first {
+        return segment.text.count
+      }
+      return 0
+    }
+
     func padding(_ message: String) -> Int {
-        let new = Rainbow.extractModes(for: message).text.count
-        let old = Rainbow.extractModes(for: self.message).text.count
+        let new = entryLength(entry: Rainbow.extractEntry(for: message))
+        let old = entryLength(entry: Rainbow.extractEntry(for: self.message))
         let diff: Int = old - new
         if diff > 0 {
             return diff
@@ -213,8 +220,8 @@ public final class Spinner {
     }
 
     func padding(_ animation: SpinnerAnimation) -> Int {
-        let new: Int = Rainbow.extractModes(for: animation.frames[0]).text.count
-        let old: Int = Rainbow.extractModes(for: self.animation.frames[0]).text.count
+        let new = entryLength(entry: Rainbow.extractEntry(for: animation.frames[0]))
+        let old = entryLength(entry: Rainbow.extractEntry(for: self.animation.frames[0]))
         let diff: Int = old - new
         if diff > 0 {
             return diff


### PR DESCRIPTION
The `Rainbow.extractModes` method is now deprecated. We should use `Rainbow.extractModes(from:)` instead. This returns a `Rainbow.Entry` object that contains the nodes. We implement an internal `Spinner.entryLength` that returns the length of the `Rainbow.Entry` object to enable us to calculate the padding of messages and animations.

closes: https://github.com/dominicegginton/spinner/issues/46